### PR TITLE
fix(editorconfig-linters/pom.xml): remove not used dependency:org.ecl…

### DIFF
--- a/editorconfig-linters/pom.xml
+++ b/editorconfig-linters/pom.xml
@@ -46,12 +46,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
-      <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.15.0</version>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
…ipse.jdt.core

In the org.eclipse.jdt.core pom.xml,its have such as dependency:
```
    <dependency>
      <groupId>org.eclipse.platform</groupId>
      <artifactId>org.eclipse.core.resources</artifactId>
      <version>[3.12.0,4.0.0)</version>
    </dependency>
```
it will slow down the maven build process (versions resolve-ranges)