### PR TITLE
fix two bug

### DIFF
--- a/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/FormattingHandler.java
+++ b/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/FormattingHandler.java
@@ -89,7 +89,8 @@ public class FormattingHandler implements ViolationHandler {
                     final Integer line = Integer.valueOf(loc.getLine());
                     if (!linesEdited.contains(line)) {
                         int lineStartOffset = currentFile.findLineStart(loc.getLine());
-                        int editOffset = lineStartOffset + loc.getColumn() - 1;
+                        final int col = loc.getColumn();
+                        int editOffset = col < 0 ? lineStartOffset : lineStartOffset + col - 1;
                         final Edit fix = violation.getFix();
                         log.debug("About to perform '{}' at {}, lineStartOffset {}, editOffset {}", fix.getMessage(),
                                 loc, lineStartOffset, editOffset);


### PR DESCRIPTION
56818f2 fix(editorconfig-lint-api): fix Resource.findLineStart precheck logic(& -> ||)
748781b fix(editorconfig-lint-api): fix a FormattingHandler.endFile logic

input:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
	<module name="TreeWalker">
        <module name="SuppressionCommentFilter">
			<!-- ABC -->
	        <property name="checkFormat" value="RegexpSinglelineJavaCheck"/>
	    </module>
	</module>
</module>
```
output:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="SuppressionCommentFilter">
			<!-- ABC --        <property name="checkFormat" value="RegexpSinglelineJavaCheck"/>
	    </module>
</module>
  /module>
```