### PR TITLE
XmlLinter: Negative column numbers when the dirty region was longer than

### DIFF
--- a/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/LintUtils.java
+++ b/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/LintUtils.java
@@ -106,4 +106,36 @@ public class LintUtils {
         return source;
     }
 
+    /**
+     * Asserts that the given {@code number} is a valid line number or a valid column number - i.e. a number greater or
+     * equal to {@code 1}.
+     *
+     * @param number the line number or column number to validate
+     * @param name {@code "line"} or {@code "column"}
+     * @return the {@code number}
+     * @throws IllegalArgumentException if the {@code number} is invalid
+     */
+    public static int validateLineOrColumnNumber(int number, String name) {
+        if (number < 1) {
+            throw new IllegalArgumentException(String.format("%s must be greater or equal to 1", name));
+        }
+        return number;
+    }
+
+    /**
+     * Asserts that the given {@code length} is a valid length - i.e. a number greater or
+     * equal to {@code 0}.
+     *
+     * @param length the length to validate
+     * @param name the name of the validated parameter
+     * @return the {@code length}
+     * @throws IllegalArgumentException if the {@code length} is invalid
+     */
+    public static int validateLength(int length, String name) {
+        if (length < 0) {
+            throw new IllegalArgumentException(String.format("%s must be greater or equal to 0", name));
+        }
+        return length;
+    }
+
 }

--- a/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Location.java
+++ b/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Location.java
@@ -38,8 +38,8 @@ public class Location {
 
     public Location(int line, int column) {
         super();
-        this.line = line;
-        this.column = column;
+        this.line = LintUtils.validateLineOrColumnNumber(line, "line");
+        this.column = LintUtils.validateLineOrColumnNumber(column, "column");
     }
 
     @Override

--- a/editorconfig-linters/src/main/java/org/ec4j/linters/Indent.java
+++ b/editorconfig-linters/src/main/java/org/ec4j/linters/Indent.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2017 EditorConfig Linters
+ * project contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ec4j.linters;
+
+import java.util.BitSet;
+
+import org.ec4j.lint.api.LintUtils;
+
+/**
+ * An indent occurrence within a file characterized by {@link #lineNumber} and {@link #size}.
+ */
+public class Indent {
+
+    /**
+     * An {@link Indent} usable at the beginning of a typical XML file.
+     */
+    public static final Indent START = new Indent(1, 0, -1, 0);
+
+    public static Indent of(int lineNumber, int size, BitSet edits, int editsLength) {
+        if (editsLength == 0) {
+            return new Indent(lineNumber, size, -1, 0);
+        } else {
+            int badStartColumn = 1;
+            int badLength = editsLength;
+            for (int i = editsLength - 1; i >= 0; i--) {
+                if (!edits.get(i)) {
+                    badLength--;
+                    badStartColumn++;
+                } else {
+                    break;
+                }
+            }
+            return new Indent(lineNumber, size, badStartColumn, badLength);
+        }
+    }
+
+    /**
+     * The number of elements that need to be replaced or removed.
+     */
+    private final int badLength;
+
+    /**
+     * The 1-based column number where the first bad indent character is located. Values lower than {@code 1}
+     * mean that there are no elements to be replaced or removed.
+     */
+    private final int badStartColumn;
+
+    /**
+     * The line number where this {@link Indent} occurs. The first line number in a file is {@code 1}.
+     */
+    private final int lineNumber;
+
+    /** The number of spaces in this {@link Indent}. */
+    private final int size;
+
+    Indent(int lineNumber, int size, int badStartColumn, int badLength) {
+        super();
+        this.lineNumber = LintUtils.validateLineOrColumnNumber(lineNumber, "line");
+        this.size = LintUtils.validateLength(size, "size");
+        this.badStartColumn = badStartColumn;
+        this.badLength = LintUtils.validateLength(badLength, "badLenght");
+    }
+
+    @Override
+    public String toString() {
+        return "Indent [lineNumber=" + lineNumber + ", size=" + size + ", badLength=" + badLength
+                + ", badStartColumn=" + badStartColumn + "]";
+    }
+
+    public int getBadLength() {
+        return badLength;
+    }
+
+    public int getBadStartColumn() {
+        assert badLength == 0 || badStartColumn >= 1 : "badStartColumn must be greater or equal to 1 unless badLength is 0";
+        return badStartColumn;
+    }
+
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+}

--- a/editorconfig-linters/src/test/java/org/ec4j/linters/XmlLinterTest.java
+++ b/editorconfig-linters/src/test/java/org/ec4j/linters/XmlLinterTest.java
@@ -34,6 +34,30 @@ public class XmlLinterTest {
     private final Linter linter = new XmlLinter();
 
     @Test
+    public void ignoreMisalignedComment() throws Exception {
+        String text = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t\t\t<!-- comment -->\n" + //
+                " <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        String expectedText = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t\t\t<!-- comment -->\n" + //
+                " <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        Resource doc = LinterTestUtils.createDocument(text, ".xml");
+
+        final ResourceProperties props = ResourceProperties.builder() //
+                .property(new Property.Builder(null).type(PropertyType.indent_size).value("1").build()) //
+                .property(new Property.Builder(null).type(PropertyType.indent_style).value("space").build()) //
+                .property(new Property.Builder(null).type(PropertyType.trim_trailing_whitespace).value("true").build()) //
+                .build();
+
+        /* No violations expected */
+        LinterTestUtils.assertParse(linter, doc, expectedText, props);
+    }
+
+    @Test
     public void indentedRootElement() throws IOException {
         String text = "        <root>\n" + //
                 "            <child1>\n" + //
@@ -141,6 +165,55 @@ public class XmlLinterTest {
                         IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "2"), //
                 new Violation(doc, new Location(6, 3), new Delete(2), linter, PropertyType.indent_style.getName(),
                         IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "2"));
+    }
+
+    @Test
+    public void spacesForMixedTooLong() throws Exception {
+        String text = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t     \t<text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        String expectedText = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                " <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        Resource doc = LinterTestUtils.createDocument(text, ".xml");
+
+        final ResourceProperties props = ResourceProperties.builder() //
+                .property(new Property.Builder(null).type(PropertyType.indent_size).value("1").build()) //
+                .property(new Property.Builder(null).type(PropertyType.indent_style).value("space").build()) //
+                .property(new Property.Builder(null).type(PropertyType.trim_trailing_whitespace).value("true").build()) //
+                .build();
+
+        LinterTestUtils.assertParse(linter, doc, expectedText, props, new Violation(doc, new Location(3, 1), //
+                Replace.indent(7, IndentStyleValue.space, 1), linter, PropertyType.indent_style.getName(),
+                IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "1"));
+    }
+
+    @Test
+    public void spacesForTabsAfterMisalignedComment() throws Exception {
+        String text = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t\t\t<!-- comment -->\n" + //
+                "\t     <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        String expectedText = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t\t\t<!-- comment -->\n" + //
+                " <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        Resource doc = LinterTestUtils.createDocument(text, ".xml");
+
+        final ResourceProperties props = ResourceProperties.builder() //
+                .property(new Property.Builder(null).type(PropertyType.indent_size).value("1").build()) //
+                .property(new Property.Builder(null).type(PropertyType.indent_style).value("space").build()) //
+                .property(new Property.Builder(null).type(PropertyType.trim_trailing_whitespace).value("true").build()) //
+                .build();
+
+        /* No violations expected */
+        LinterTestUtils.assertParse(linter, doc, expectedText, props, new Violation(doc, new Location(4, 1), //
+                new Delete(5), linter, PropertyType.indent_style.getName(),
+                IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "1"));
     }
 
     @Test
@@ -797,6 +870,29 @@ public class XmlLinterTest {
                 new Violation(doc, new Location(3, 1), //
                         Replace.indent(1, IndentStyleValue.space, 1), linter, PropertyType.indent_style.getName(),
                         IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "1"));
+    }
+
+    @Test
+    public void spacesForTabsTooLong() throws Exception {
+        String text = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                "\t     <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        String expectedText = "<?xml version=\"1.0\"?>\n" + //
+                "<root>\n" + //
+                " <text-1>text in text-1</text-1>\n" + //
+                "</root>"; //
+        Resource doc = LinterTestUtils.createDocument(text, ".xml");
+
+        final ResourceProperties props = ResourceProperties.builder() //
+                .property(new Property.Builder(null).type(PropertyType.indent_size).value("1").build()) //
+                .property(new Property.Builder(null).type(PropertyType.indent_style).value("space").build()) //
+                .property(new Property.Builder(null).type(PropertyType.trim_trailing_whitespace).value("true").build()) //
+                .build();
+
+        LinterTestUtils.assertParse(linter, doc, expectedText, props, new Violation(doc, new Location(3, 1), //
+                new Delete(5), linter, PropertyType.indent_style.getName(),
+                IndentStyleValue.space.name(), PropertyType.indent_size.getName(), "1"));
     }
 
 }


### PR DESCRIPTION
the expected indent

The issue was reported in
https://github.com/ec4j/editorconfig-linters/pull/14 by @qxo