### PR TITLE
Exclude logs.

### DIFF
--- a/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java
+++ b/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java
@@ -191,7 +191,10 @@ public final class Constants {
             // fonts
             "**/*.eot", //
             "**/*.ttf", //
-            "**/*.woff" //
+            "**/*.woff", //
+
+            // log files
+            "**/*.log" //
 
     )));
 


### PR DESCRIPTION
### :pencil: Description
Hi!
I think log files should be excluded by default. Usually these are pretty long and linting them would most possibly fail the builds.