### PR TITLE
Ignore .idea subdirectories everywhere, not just in the root directory

### DIFF
--- a/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java
+++ b/editorconfig-lint-api/src/main/java/org/ec4j/lint/api/Constants.java
@@ -128,7 +128,7 @@ public final class Constants {
             "**/*.iml", //
             "**/*.ipr", //
             "**/*.iws", //
-            ".idea/**", //
+            "**/.idea/**", //
 
             // Netbeans
             "**/nb-configuration.xml", //


### PR DESCRIPTION
All other default excludes are prefixed with `**/` - the `.idea` folder is the only exception.
I don't think this is intentional (and rather a typo); IDEA IntelliJ (and other related IDEs like PyCharm) create this directory in the chosen project root, and this can be anywhere in the repository (and typically right next to the related `*.iml` config).

For example, I have a repository that has a central Java project, but also Python scripts for a GitHub action in a `.github/actions/foo` subdirectory. The editorconfig-maven-plugin correctly ignores the main IntelliJ configuration at `/.idea`, but complains about a huge list of files once I set up a PyCharm project at `/.github/actions/foo/.idea`; that's unexpected and inconsistent!